### PR TITLE
Fix various showstoppers related to the notification listener service

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,10 +36,10 @@
 
             <meta-data
                 android:name="android.service.notification.default_filter_types"
-                android:value="conversations,alerting" />
+                android:value="conversations|alerting" />
             <meta-data
                 android:name="android.service.notification.disabled_filter_types"
-                android:value="ongoing,silent" />
+                android:value="ongoing|silent" />
         </service>
 
         <receiver

--- a/app/src/main/kotlin/com/boswelja/autoevent/notificationeventextractor/NotiListenerService.kt
+++ b/app/src/main/kotlin/com/boswelja/autoevent/notificationeventextractor/NotiListenerService.kt
@@ -1,8 +1,5 @@
 package com.boswelja.autoevent.notificationeventextractor
 
-import android.content.Intent
-import android.os.Binder
-import android.os.IBinder
 import android.service.notification.NotificationListenerService
 import android.service.notification.StatusBarNotification
 import kotlinx.coroutines.CoroutineScope
@@ -14,8 +11,6 @@ class NotiListenerService : NotificationListenerService() {
     private val coroutineScope = CoroutineScope(Dispatchers.Default)
 
     private lateinit var notiExtractor: NotiEventExtractor
-
-    override fun onBind(intent: Intent?): IBinder = Binder()
 
     override fun onListenerConnected() {
         notiExtractor = NotiEventExtractor(applicationContext)

--- a/app/src/main/kotlin/com/boswelja/autoevent/notificationeventextractor/NotiListenerService.kt
+++ b/app/src/main/kotlin/com/boswelja/autoevent/notificationeventextractor/NotiListenerService.kt
@@ -22,7 +22,7 @@ class NotiListenerService : NotificationListenerService() {
     }
 
     override fun onListenerDisconnected() {
-        notiExtractor.close()
+        if (::notiExtractor.isInitialized) notiExtractor.close()
     }
 
     override fun onNotificationPosted(sbn: StatusBarNotification?) {


### PR DESCRIPTION
- Fixed a crash when stopping the service before it's been set up
- Fixed an issue that caused the service to magically not be connected
- Fixed an issue where the default settings for allowed notifications wasn't set correctly